### PR TITLE
Set cmd's optional params as pointers

### DIFF
--- a/cli/device/create.go
+++ b/cli/device/create.go
@@ -31,9 +31,13 @@ func runCreateCommand(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Creating device with name %s\n", createFlags.name)
 
 	params := &device.CreateParams{
-		Port: createFlags.port,
 		Name: createFlags.name,
-		Fqbn: createFlags.fqbn,
+	}
+	if createFlags.port != "" {
+		params.Port = &createFlags.port
+	}
+	if createFlags.fqbn != "" {
+		params.Fqbn = &createFlags.fqbn
 	}
 
 	devID, err := device.Create(params)

--- a/cli/thing/create.go
+++ b/cli/thing/create.go
@@ -29,8 +29,10 @@ func runCreateCommand(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Creating thing from template %s\n", createFlags.template)
 
 	params := &thing.CreateParams{
-		Name:     createFlags.name,
 		Template: createFlags.template,
+	}
+	if createFlags.name != "" {
+		params.Name = &createFlags.name
 	}
 
 	thingID, err := thing.Create(params)

--- a/cli/thing/extract.go
+++ b/cli/thing/extract.go
@@ -28,7 +28,9 @@ func initExtractCommand() *cobra.Command {
 func runExtractCommand(cmd *cobra.Command, args []string) error {
 	fmt.Printf("Extracting template from thing %s\n", extractFlags.id)
 
-	params := &thing.ExtractParams{ID: extractFlags.id}
+	params := &thing.ExtractParams{
+		ID: extractFlags.id,
+	}
 	if extractFlags.outfile != "" {
 		params.Outfile = &extractFlags.outfile
 	}

--- a/command/device/create_test.go
+++ b/command/device/create_test.go
@@ -35,6 +35,10 @@ var (
 	}
 )
 
+func stringPointer(s string) *string {
+	return &s
+}
+
 func TestDeviceFromPorts(t *testing.T) {
 	tests := []struct {
 		name   string
@@ -45,28 +49,28 @@ func TestDeviceFromPorts(t *testing.T) {
 
 		{
 			name:   "port-filter",
-			filter: &CreateParams{Fqbn: "", Port: "ACM1"},
+			filter: &CreateParams{Fqbn: nil, Port: stringPointer("ACM1")},
 			ports:  portsTwoBoards,
 			want:   &device{fqbn: "arduino:avr:uno", port: "ACM1"},
 		},
 
 		{
 			name:   "fqbn-filter",
-			filter: &CreateParams{Fqbn: "arduino:avr:uno", Port: ""},
+			filter: &CreateParams{Fqbn: stringPointer("arduino:avr:uno"), Port: nil},
 			ports:  portsTwoBoards,
 			want:   &device{fqbn: "arduino:avr:uno", port: "ACM1"},
 		},
 
 		{
 			name:   "no-filter-noboards",
-			filter: &CreateParams{Fqbn: "", Port: ""},
+			filter: &CreateParams{Fqbn: nil, Port: nil},
 			ports:  portsNoBoards,
 			want:   nil,
 		},
 
 		{
 			name:   "no-filter",
-			filter: &CreateParams{Fqbn: "", Port: ""},
+			filter: &CreateParams{Fqbn: nil, Port: nil},
 			ports:  portsTwoBoards,
 			// first device found is selected
 			want: &device{fqbn: "arduino:samd:nano_33_iot", port: "ACM0"},
@@ -74,21 +78,21 @@ func TestDeviceFromPorts(t *testing.T) {
 
 		{
 			name:   "both-filter-noboards",
-			filter: &CreateParams{Fqbn: "arduino:avr:uno", Port: "ACM1"},
+			filter: &CreateParams{Fqbn: stringPointer("arduino:avr:uno"), Port: stringPointer("ACM1")},
 			ports:  portsNoBoards,
 			want:   nil,
 		},
 
 		{
 			name:   "both-filter-found",
-			filter: &CreateParams{Fqbn: "arduino:avr:uno", Port: "ACM1"},
+			filter: &CreateParams{Fqbn: stringPointer("arduino:avr:uno"), Port: stringPointer("ACM1")},
 			ports:  portsTwoBoards,
 			want:   &device{fqbn: "arduino:avr:uno", port: "ACM1"},
 		},
 
 		{
 			name:   "both-filter-notfound",
-			filter: &CreateParams{Fqbn: "arduino:avr:uno", Port: "ACM0"},
+			filter: &CreateParams{Fqbn: stringPointer("arduino:avr:uno"), Port: stringPointer("ACM0")},
 			ports:  portsTwoBoards,
 			want:   nil,
 		},

--- a/command/thing/create.go
+++ b/command/thing/create.go
@@ -15,7 +15,7 @@ import (
 // CreateParams contains the parameters needed to create a new thing.
 type CreateParams struct {
 	// Optional - contains the name of the thing
-	Name string
+	Name *string
 	// Mandatory - contains the path of the template file
 	Template string
 }
@@ -37,8 +37,8 @@ func Create(params *CreateParams) (string, error) {
 	}
 
 	// Name passed as parameter has priority over name from template
-	if params.Name != "" {
-		thing.Name = params.Name
+	if params.Name != nil {
+		thing.Name = *params.Name
 	}
 	// If name is not specified in the template, it should be passed as parameter
 	if thing.Name == "" {


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
All implemented commands now accept optional parameters as pointers. 
This change makes the command package more clear and easier to use: if the type of a parameter is a pointer, then it becomes clear that such parameter is optional. So, for example, instead of an empty string now it's possible to pass `nil` for optional parameters.  

### Change description
<!-- What does your code do? -->

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
