### PR TITLE
Wait a while before using serial port

### DIFF
--- a/command/device/provision.go
+++ b/command/device/provision.go
@@ -80,7 +80,7 @@ func (p provision) run() error {
 	defer p.ser.Close()
 
 	// Wait some time before using the serial port
-	time.Sleep(1500 * time.Millisecond)
+	time.Sleep(2000 * time.Millisecond)
 	logrus.Infof("%s\n\n", "Connected to the board")
 
 	// Send configuration commands to the board

--- a/internal/serial/serial.go
+++ b/internal/serial/serial.go
@@ -55,7 +55,7 @@ func (s *Serial) Connect(address string) error {
 	}
 	s.port = port
 
-	s.port.SetReadTimeout(time.Millisecond * 4000)
+	s.port.SetReadTimeout(time.Millisecond * 2500)
 	return nil
 }
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
for some unknown reason we have to add a few second delay between the opening of the serial port and the start of serial communication.  

### Change description
<!-- What does your code do? -->
Add 2 seconds sleep before sending the first serial message to the device 

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
