### PR TITLE
Delete in bulks

### DIFF
--- a/cli/thing/delete.go
+++ b/cli/thing/delete.go
@@ -11,30 +11,30 @@ import (
 )
 
 var deleteFlags struct {
-	id string
+	ids []string
 }
 
 func initDeleteCommand() *cobra.Command {
 	deleteCommand := &cobra.Command{
 		Use:   "delete",
-		Short: "Delete a thing",
-		Long:  "Delete a thing from Arduino IoT Cloud",
+		Short: "Delete things",
+		Long:  "Delete a list of things from Arduino IoT Cloud",
 		Run:   runDeleteCommand,
 	}
-	deleteCommand.Flags().StringVarP(&deleteFlags.id, "id", "i", "", "Thing ID")
-	deleteCommand.MarkFlagRequired("id")
+	deleteCommand.Flags().StringSliceVarP(&deleteFlags.ids, "ids", "i", []string{}, "List of comma-separated thing IDs to be deleted")
+	deleteCommand.MarkFlagRequired("ids")
 	return deleteCommand
 }
 
 func runDeleteCommand(cmd *cobra.Command, args []string) {
-	logrus.Infof("Deleting thing %s\n", deleteFlags.id)
+	logrus.Infof("Deleting things %v\n", deleteFlags.ids)
 
-	params := &thing.DeleteParams{ID: deleteFlags.id}
+	params := &thing.DeleteParams{IDs: deleteFlags.ids}
 	err := thing.Delete(params)
 	if err != nil {
-		feedback.Errorf("Error during thing delete: %v", err)
+		feedback.Errorf("Error during thing delete: %s", err)
 		os.Exit(errorcodes.ErrGeneric)
 	}
 
-	logrus.Info("Thing successfully deleted")
+	logrus.Info("Things successfully deleted")
 }

--- a/command/thing/delete.go
+++ b/command/thing/delete.go
@@ -1,17 +1,20 @@
 package thing
 
 import (
+	"errors"
+	"fmt"
+
 	"github.com/arduino/iot-cloud-cli/internal/config"
 	"github.com/arduino/iot-cloud-cli/internal/iot"
 )
 
 // DeleteParams contains the parameters needed to
-// delete a thing from Arduino IoT Cloud.
+// delete a list of things from Arduino IoT Cloud.
 type DeleteParams struct {
-	ID string
+	IDs []string
 }
 
-// Delete command is used to delete a thing
+// Delete command is used to delete things
 // from Arduino IoT Cloud.
 func Delete(params *DeleteParams) error {
 	conf, err := config.Retrieve()
@@ -23,5 +26,16 @@ func Delete(params *DeleteParams) error {
 		return err
 	}
 
-	return iotClient.ThingDelete(params.ID)
+	result := ""
+	for _, id := range params.IDs {
+		err = iotClient.ThingDelete(id)
+		if err != nil {
+			result = fmt.Sprintf("%s\nthing id %s: %s", result, id, err)
+		}
+	}
+
+	if result != "" {
+		return errors.New(result)
+	}
+	return nil
 }


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
users may want to delete many devices/things at once

### Change description
<!-- What does your code do? -->
delete commands now take a list of ids instead of a single id
The command execution iterates over the passed ids and tries to delete all of them. If errors are encountered, the loop doesn't return and the error information is "accumulated" into a result string. 
At the end of the loop, if the result string is not empty then it is passed as an error.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
