### PR TITLE
Improve config security

### DIFF
--- a/command/config/init.go
+++ b/command/config/init.go
@@ -20,6 +20,7 @@ package config
 import (
 	"errors"
 	"fmt"
+	"os"
 	"strings"
 
 	"github.com/arduino/arduino-cloud-cli/internal/config"
@@ -65,6 +66,7 @@ func Init(params *InitParams) error {
 	}
 
 	newSettings := viper.New()
+	newSettings.SetConfigPermissions(os.FileMode(0600))
 	config.SetDefaults(newSettings)
 	if err := newSettings.WriteConfigAs(configFile.String()); err != nil {
 		return fmt.Errorf("cannot create config file: %v", err)


### PR DESCRIPTION
### Motivation
Since the configuration file of the CLI contains secrets, it should be
readable only to its owner ~and his group~.

### Change description
- Change permissions of generated config file from default `644` to ~`640`~ `600`