### PR TITLE
Pin Task version to 3.9.0

### DIFF
--- a/.github/workflows/release-go-task.yml
+++ b/.github/workflows/release-go-task.yml
@@ -39,7 +39,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 3.9.0
 
       - name: Build
         run: task dist:all

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -86,7 +86,7 @@ jobs:
         uses: arduino/setup-task@v1
         with:
           repo-token: ${{ secrets.GITHUB_TOKEN }}
-          version: 3.x
+          version: 3.9.0
 
       - name: Run tests
         env:


### PR DESCRIPTION
### Motivation
Task 3.9.1 has an issue with the PATH environment variable on Windows: it is not correctly expanded in subcommands and go fails to find gcc.

This is causing failures on our CI.


### Change description
- Pin Task to version 3.9.0

### Additional Notes
Logs of a CI failure: [2_test (. - windows-latest).txt](https://github.com/arduino/arduino-cloud-cli/files/7627130/2_test.-.windows-latest.txt)
Related issue on arduino-cli: https://github.com/arduino/arduino-cli/pull/1576

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are properly filled.
* [x] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
