### PR TITLE
Make arduino15 dir if not exist

### DIFF
--- a/cli/config/init.go
+++ b/cli/config/init.go
@@ -65,6 +65,13 @@ func runInitCommand(cmd *cobra.Command, args []string) {
 			feedback.Errorf("Error during config init: cannot retrieve arduino default directory: %v", err)
 			os.Exit(errorcodes.ErrGeneric)
 		}
+		// Create arduino default directory if it does not exist
+		if configPath.NotExist() {
+			if err = configPath.MkdirAll(); err != nil {
+				feedback.Errorf("Error during config init: cannot create arduino default directory %s: %v", configPath, err)
+				os.Exit(errorcodes.ErrGeneric)
+			}
+		}
 		initFlags.destDir = configPath.String()
 	}
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
During `config init` if the default arduino directory (arduino15) doesn't exist then we want to create it rather than returning an error.

### Change description
<!-- What does your code do? -->
the check `		if configPath.NotExist() {` is not mandatory because `configPath.MkdirAll()` doesn't do anything if the directory exists already. However I put it to avoid cases where the call to `MkdirAll` fails even if the directory already exists. 

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
