### PR TITLE
Rename fields of printed structs to snake case

### DIFF
--- a/cli/device/create.go
+++ b/cli/device/create.go
@@ -80,7 +80,7 @@ func (r createResult) Data() interface{} {
 
 func (r createResult) String() string {
 	return fmt.Sprintf(
-		"name: %s\nid: %s\nboard: %s\nserial-number: %s\nfqbn: %s",
+		"name: %s\nid: %s\nboard: %s\nserial_number: %s\nfqbn: %s",
 		r.device.Name,
 		r.device.ID,
 		r.device.Board,

--- a/cli/device/creategeneric.go
+++ b/cli/device/creategeneric.go
@@ -73,7 +73,7 @@ func (r createGenericResult) Data() interface{} {
 
 func (r createGenericResult) String() string {
 	return fmt.Sprintf(
-		"id: %s\nsecret-key: %s\nname: %s\nboard: %s\nserial-number: %s\nfqbn: %s",
+		"id: %s\nsecret_key: %s\nname: %s\nboard: %s\nserial_number: %s\nfqbn: %s",
 		r.device.ID,
 		r.device.Password,
 		r.device.Name,

--- a/cli/device/createlora.go
+++ b/cli/device/createlora.go
@@ -87,8 +87,8 @@ func (r createLoraResult) Data() interface{} {
 
 func (r createLoraResult) String() string {
 	return fmt.Sprintf(
-		"name: %s\nid: %s\nboard: %s\nserial-number: %s\nfqbn: %s"+
-			"\napp-eui: %s\napp-key: %s\neui: %s",
+		"name: %s\nid: %s\nboard: %s\nserial_number: %s\nfqbn: %s"+
+			"\napp_eui: %s\napp_key: %s\neui: %s",
 		r.device.Name,
 		r.device.ID,
 		r.device.Board,

--- a/cli/thing/clone.go
+++ b/cli/thing/clone.go
@@ -75,7 +75,7 @@ func (r cloneResult) Data() interface{} {
 
 func (r cloneResult) String() string {
 	return fmt.Sprintf(
-		"name: %s\nid: %s\ndevice-id: %s\nvariables: %s",
+		"name: %s\nid: %s\ndevice_id: %s\nvariables: %s",
 		r.thing.Name,
 		r.thing.ID,
 		r.thing.DeviceID,

--- a/cli/thing/create.go
+++ b/cli/thing/create.go
@@ -82,7 +82,7 @@ func (r createResult) Data() interface{} {
 
 func (r createResult) String() string {
 	return fmt.Sprintf(
-		"name: %s\nid: %s\ndevice-id: %s\nvariables: %s",
+		"name: %s\nid: %s\ndevice_id: %s\nvariables: %s",
 		r.thing.Name,
 		r.thing.ID,
 		r.thing.DeviceID,

--- a/command/device/creategeneric.go
+++ b/command/device/creategeneric.go
@@ -39,7 +39,7 @@ type CreateGenericParams struct {
 // parameters of a generic Arduino IoT Cloud device.
 type DeviceGenericInfo struct {
 	DeviceInfo
-	Password string `json:"secret-key"`
+	Password string `json:"secret_key"`
 }
 
 // CreateGeneric command is used to add a new generic device to Arduino IoT Cloud.

--- a/command/device/createlora.go
+++ b/command/device/createlora.go
@@ -48,8 +48,8 @@ const (
 // parameters of an Arduino IoT Cloud LoRa device.
 type DeviceLoraInfo struct {
 	DeviceInfo
-	AppEUI string `json:"app-eui"`
-	AppKey string `json:"app-key"`
+	AppEUI string `json:"app_eui"`
+	AppKey string `json:"app_key"`
 	EUI    string `json:"eui"`
 }
 

--- a/command/device/device.go
+++ b/command/device/device.go
@@ -28,7 +28,7 @@ type DeviceInfo struct {
 	Name   string   `json:"name"`
 	ID     string   `json:"id"`
 	Board  string   `json:"board"`
-	Serial string   `json:"serial-number"`
+	Serial string   `json:"serial_number"`
 	FQBN   string   `json:"fqbn"`
 	Tags   []string `json:"tags,omitempty"`
 }

--- a/command/thing/thing.go
+++ b/command/thing/thing.go
@@ -27,7 +27,7 @@ import (
 type ThingInfo struct {
 	Name      string   `json:"name"`
 	ID        string   `json:"id"`
-	DeviceID  string   `json:"device-id"`
+	DeviceID  string   `json:"device_id"`
 	Variables []string `json:"variables"`
 	Tags      []string `json:"tags,omitempty"`
 }


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
Improvement to make cli feedback a bit more programmers and tools friendly. Without this change, you have to quote the name of the variables to prevent a parser to interpret to -  as an arithmetic (or whatever) minus sign. 
from @manchoz 

### Change description
<!-- What does your code do? -->
rename printed fields and json tags to snake case

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
