### PR TITLE
Update provisioning sketch based on ArduinoIoTCloud library 1.6.0

### DIFF
--- a/firmware/provision/CryptoProvision/CryptoProvision.ino
+++ b/firmware/provision/CryptoProvision/CryptoProvision.ino
@@ -516,14 +516,7 @@ void processCommand() {
     sendData(MESSAGE_TYPE::RESPONSE, response, 1);
   }
   if (cmdCode == COMMAND::RECONSTRUCT_CERT) {
-
-    if (!Cert.begin()) {
-      Serial1.println("Error starting Crypto cert reconstruction!");
-      char response[] = {char(RESPONSE::RESPONSE_ERROR)};
-      sendData(MESSAGE_TYPE::RESPONSE, response, 1);
-      return;
-    }
-
+    Serial1.println("reconstruct certificate");
     if (!Crypto.readCert(Cert, CryptoSlot::CompressedCertificate)) {
       Serial1.println("Error reconstructing Crypto cert!");
       char response[] = {char(RESPONSE::RESPONSE_ERROR)};


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
With the introduction of NICLA VISION and SE050 crypto the provisioning sketch needs to be updated following the changes in ArduinoIoTCloud library

### Change description
<!-- What does your code do? -->
 - Adds support for NICLA VISION and SE050 crypto
 - Minor changes in Certificate creation
 - Removed Crypto SN read and print because of missing abstraction in ArduinoIoTCloud CryptoUtil

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->
Tested on:
|  Board | Provisioning  | Connection  |  
|---|---|---|
| MKR WiFi 1010  | :heavy_check_mark:   | :heavy_check_mark:   |
|  NANO 33 IoT | :heavy_check_mark:   |:heavy_check_mark:    | 
|  NANO RP 2040 Connect  |:heavy_check_mark:    | :heavy_check_mark:   | 
|  Nicla Vision | :heavy_check_mark:   | :heavy_check_mark:   |
|  Portenta H7 | :heavy_check_mark:   |  :heavy_check_mark:  | 
|  MKR GSM 1400 |  :heavy_check_mark:  |  :heavy_check_mark:  |   
|  MKR NB 1500 | :heavy_check_mark:   | :grey_question:   | 


### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
