### PR TITLE
Use credentials IsEmpty again

### DIFF
--- a/internal/config/credentials.go
+++ b/internal/config/credentials.go
@@ -86,9 +86,9 @@ func (c *Credentials) Validate() error {
 	return nil
 }
 
-// Complete checks if Credentials has all the mandatory params set.
+// IsEmpty checks if Credentials has no mandatory params set.
 // Optional parameters are not considered here.
-func (c *Credentials) Complete() bool {
+func (c *Credentials) IsEmpty() bool {
 	return len(c.Client) == 0 && len(c.Secret) == 0
 }
 
@@ -104,7 +104,7 @@ func FindCredentials() (source string, err error) {
 	if err != nil {
 		return "", fmt.Errorf("looking for credentials in environment variables: %w", err)
 	}
-	if c.Complete() {
+	if !c.IsEmpty() {
 		logrus.Infof("Credentials found in environment variables with prefix '%s'", EnvPrefix)
 		return "environment variables", nil
 	}
@@ -136,7 +136,7 @@ func RetrieveCredentials() (cred *Credentials, err error) {
 		return nil, fmt.Errorf("reading credentials from environment variables: %w", err)
 	}
 	// Returns credentials if found in env
-	if !cred.Complete() {
+	if !cred.IsEmpty() {
 		// Returns error if credentials are found but are not valid
 		if err := cred.Validate(); err != nil {
 			return nil, fmt.Errorf(

--- a/internal/config/credentials_test.go
+++ b/internal/config/credentials_test.go
@@ -252,7 +252,7 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-func TestComplete(t *testing.T) {
+func TestIsEmpty(t *testing.T) {
 	var (
 		validSecret       = "qaRZGEbnQNNvmaeTLqy8Bxs22wLZ6H7obIiNSveTLPdoQuylANnuy6WBOw16XoqH"
 		validClient       = "CQ4iZ5sebOfhGRwUn3IV0r1YFMNrMTIx"
@@ -283,11 +283,16 @@ func TestComplete(t *testing.T) {
 			config: &Credentials{Client: validClient, Secret: ""},
 			want:   false,
 		},
+		{
+			name:   "credentials with all mandatory params set",
+			config: &Credentials{Client: validClient, Secret: validSecret},
+			want:   false,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := tt.config.Complete()
+			got := tt.config.IsEmpty()
 			if got != tt.want {
 				t.Errorf("Expected %v but got %v, with credentials: %v", tt.want, got, tt.config)
 			}


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
There is a nasty leftover: I changed the name of credentials `IsEmpty` method without changing its logic.
Also, we actually need to know if the credentials config file has any mandatory parameter or not. Thus, the name `IsEmpty` fits better this need.

### Change description
<!-- What does your code do? -->
Put back the old `IsEmpty` name.

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
