### PR TITLE
Accept and propagate context

### DIFF
--- a/command/device/listfqbn.go
+++ b/command/device/listfqbn.go
@@ -41,10 +41,16 @@ type FQBNInfo struct {
 
 // ListFQBN command returns a list of the supported FQBN.
 func ListFQBN(ctx context.Context) ([]FQBNInfo, error) {
-	h := &http.Client{Timeout: time.Second * 5}
-	resp, err := h.Get("https://builder.arduino.cc/v3/boards/")
+	url := "https://builder.arduino.cc/v3/boards/"
+	req, err := http.NewRequestWithContext(ctx, "GET", url, nil)
 	if err != nil {
-		return nil, fmt.Errorf("cannot retrieve boards from builder.arduino.cc: %w", err)
+		return nil, fmt.Errorf("cannot retrieve boards: %w", err)
+	}
+
+	h := &http.Client{Timeout: time.Second * 5}
+	resp, err := h.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("cannot retrieve boards: %w", err)
 	}
 	defer resp.Body.Close()
 


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
Every command of cloud-cli performs at least one http request. We'd like to allow users of the command package to pass a context that will be used to make those http requests.
We can also leverage context cancellation to stop the command execution.  

### Change description
<!-- What does your code do? -->
- Commands now take a context as the first input parameter.
- The context is propagated to all functions that could make an http request or that could block the execution of the program (like interactions with the serial port).
- Commands that need a cleanup before cancellation gets their context cancelled when ctrl+c is pressed, so they have time to cleanup (see [cli/device/create](https://github.com/arduino/arduino-cloud-cli/blob/99a8f270667e1a3f9de9024c2e858ddba918b210/cli/device/create.go#L79-L87)).
-  arduino-cli commands are executed in different goroutines, so that when the context gets cancelled the program will not remain blocked. The obvious problem is that the arduino-cli command execution will continue, but I don't think I can stop it in any way. In a pure cli environment this shouldn't be a problem because when the context is cancelled the entire program will terminate, together with the extra goroutines. However this can be annoying in case the command package is used from another go module (like I'm doing with arduino-cli). 
Look at it [here](https://github.com/arduino/arduino-cloud-cli/blob/93ee3361c5e8e6e4b9371ff0850a1d33e1181883/arduino/cli/commander.go#L118-L136) (I need feedback on this).

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->
references
https://www.ardanlabs.com/blog/2019/09/context-package-semantics-in-go.html
https://pace.dev/blog/2020/02/17/repond-to-ctrl-c-interrupt-signals-gracefully-with-context-in-golang-by-mat-ryer.html
https://pace.dev/blog/2020/02/03/context-aware-ioreader-for-golang-by-mat-ryer.html