### PR TITLE
Check thing template has variables

### DIFF
--- a/internal/template/load.go
+++ b/internal/template/load.go
@@ -65,7 +65,11 @@ func LoadThing(file string) (*iotclient.ThingCreate, error) {
 
 	// Adapt thing template to thing structure
 	delete(template, "id")
-	template["properties"] = template["variables"]
+	vars, ok := template["variables"]
+	if !ok {
+		return nil, errors.New("loaded thing template doesn't have a `variables` field")
+	}
+	template["properties"] = vars
 	delete(template, "variables")
 
 	// Convert template into thing structure exploiting json marshalling/unmarshalling


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
In command `thing create` the provided template MUST have a `variables` field, if that's not the case then the cli will panic

### Change description
<!-- What does your code do? -->
handle such situation and return a descriptive error instead of panic