### PR TITLE
Match thing variable_name with dashboard variable_id

### DIFF
--- a/internal/template/dashboard.go
+++ b/internal/template/dashboard.go
@@ -75,7 +75,7 @@ func getVariableID(thingID string, variableName string, fetcher ThingFetcher) (s
 	}
 
 	for _, v := range thing.Properties {
-		if v.Name == variableName {
+		if v.VariableName == variableName {
 			return v.Id, nil
 		}
 	}

--- a/internal/template/load_test.go
+++ b/internal/template/load_test.go
@@ -149,15 +149,15 @@ func (t *thingShowTest) ThingShow(thingID string) (*iotclient.ArduinoThing, erro
 	if thingID == thingOverriddenID {
 		return &iotclient.ArduinoThing{
 			Properties: []iotclient.ArduinoProperty{
-				{Id: switchyOverriddenID, Name: "switchy"},
+				{Id: switchyOverriddenID, VariableName: "switchy"},
 			},
 		}, nil
 	}
 	return &iotclient.ArduinoThing{
 		Properties: []iotclient.ArduinoProperty{
-			{Id: switchyID, Name: "switchy"},
-			{Id: relayID, Name: "relay_2"},
-			{Id: blinkSpeedID, Name: "blink_speed"},
+			{Id: switchyID, VariableName: "switchy"},
+			{Id: relayID, VariableName: "relay_2"},
+			{Id: blinkSpeedID, VariableName: "blink_speed"},
 		},
 	}, nil
 }


### PR DESCRIPTION
### Motivation
When creating a dashboard `variable_id` is matched with `name` instead of `variable_name`

### Change description
Match `variable_id` with `variable_name`

### Additional Notes

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
