### PR TITLE
[IOT-2273] Add opta support

### DIFF
--- a/.github/workflows/sync-binaries-task.yml
+++ b/.github/workflows/sync-binaries-task.yml
@@ -27,6 +27,7 @@ jobs:
           arduino-cli core install arduino:mbed_nano
           arduino-cli core install arduino:mbed_portenta
           arduino-cli core install arduino:mbed_nicla
+          arduino-cli core install arduino:mbed_opta
           arduino-cli lib install ArduinoIotCloud
           arduino-cli lib install ArduinoECCX08
           arduino-cli lib install ArduinoSTL

--- a/.licenses/go/github.com/arduino/iot-client-go.dep.yml
+++ b/.licenses/go/github.com/arduino/iot-client-go.dep.yml
@@ -1,6 +1,6 @@
 ---
 name: github.com/arduino/iot-client-go
-version: v1.4.2
+version: v1.4.4
 type: go
 summary: 
 homepage: https://pkg.go.dev/github.com/arduino/iot-client-go

--- a/README.md
+++ b/README.md
@@ -110,6 +110,21 @@ Here are the FQBNs of the Arduino boards that can be provisioned with this comma
 * `arduino:samd:mkrgsm1400`
 * `arduino:samd:mkrnb1500`
 
+If the device supports more than one connectivity type (Eg: WiFi and Ethernet) the --connection flag can be used to set the desired connectivity
+
+```bash
+arduino-cloud-cli device create --name <deviceName> --port <port> --fqbn <deviceFqbn> --connection <deviceConnectivity>
+```
+
+Here the list of available connection values:
+
+* `wifi` to set WiFi connectivity
+* `eth` to set Ethernet connectivity
+* `wifiandsecret`
+* `gsm` to set Gsm connectivity
+* `nb` to set Narrowband connectivity
+* `lora` to set Lora connectivity
+
 ### Devices with LoRaWAN connectivity
 
 LoRaWAN devices should be provisioned using a specific command.

--- a/cli/device/create.go
+++ b/cli/device/create.go
@@ -32,9 +32,10 @@ import (
 )
 
 type createFlags struct {
-	port string
-	name string
-	fqbn string
+	port  string
+	name  string
+	fqbn  string
+	ctype string
 }
 
 func initCreateCommand() *cobra.Command {
@@ -53,6 +54,7 @@ func initCreateCommand() *cobra.Command {
 	createCommand.Flags().StringVarP(&flags.port, "port", "p", "", "Device port")
 	createCommand.Flags().StringVarP(&flags.name, "name", "n", "", "Device name")
 	createCommand.Flags().StringVarP(&flags.fqbn, "fqbn", "b", "", "Device fqbn")
+	createCommand.Flags().StringVarP(&flags.ctype, "connection", "c", "", "Device connection type")
 	createCommand.MarkFlagRequired("name")
 	return createCommand
 }
@@ -67,6 +69,9 @@ func runCreateCommand(flags *createFlags) error {
 
 	params := &device.CreateParams{
 		Name: flags.name,
+	}
+	if flags.ctype != "" {
+		params.ConnectionType = &flags.ctype
 	}
 	if flags.port != "" {
 		params.Port = &flags.port

--- a/command/device/board.go
+++ b/command/device/board.go
@@ -33,6 +33,7 @@ var (
 		"arduino:samd:mkr1000",
 		"arduino:samd:mkrgsm1400",
 		"arduino:samd:mkrnb1500",
+		"arduino:mbed_opta:opta",
 	}
 	loraFQBN = []string{
 		"arduino:samd:mkrwan1310",

--- a/command/device/create.go
+++ b/command/device/create.go
@@ -31,9 +31,10 @@ import (
 // CreateParams contains the parameters needed
 // to find the device to be provisioned.
 type CreateParams struct {
-	Name string  // Device name
-	Port *string // Serial port - Optional - If omitted then each serial port is analyzed
-	FQBN *string // Board FQBN - Optional - If omitted then the first device found gets selected
+	Name           string  // Device name
+	Port           *string // Serial port - Optional - If omitted then each serial port is analyzed
+	FQBN           *string // Board FQBN - Optional - If omitted then the first device found gets selected
+	ConnectionType *string // Connection type - Optional - If omitted then the default connection type (depends on the board type) get selected
 }
 
 // Create command is used to provision a new arduino device
@@ -70,7 +71,7 @@ func Create(ctx context.Context, params *CreateParams, cred *config.Credentials)
 	}
 
 	logrus.Info("Creating a new device on the cloud")
-	dev, err := iotClient.DeviceCreate(ctx, board.fqbn, params.Name, board.serial, board.dType)
+	dev, err := iotClient.DeviceCreate(ctx, board.fqbn, params.Name, board.serial, board.dType, params.ConnectionType)
 	if err != nil {
 		return nil, err
 	}

--- a/command/device/creategeneric.go
+++ b/command/device/creategeneric.go
@@ -50,7 +50,7 @@ func CreateGeneric(ctx context.Context, params *CreateGenericParams, cred *confi
 		return nil, err
 	}
 
-	dev, err := iotClient.DeviceCreate(ctx, params.FQBN, params.Name, "", genericDType)
+	dev, err := iotClient.DeviceCreate(ctx, params.FQBN, params.Name, "", genericDType, nil)
 	if err != nil {
 		return nil, err
 	}

--- a/command/ota/generate.go
+++ b/command/ota/generate.go
@@ -37,6 +37,7 @@ var (
 		"arduino:mbed_nano:nanorp2040connect": "005E",
 		"arduino:mbed_portenta:envie_m7":      "025B",
 		"arduino:mbed_nicla:nicla_vision":     "025F",
+		"arduino:mbed_opta:opta":              "0064",
 	}
 )
 

--- a/firmware/generator.py
+++ b/firmware/generator.py
@@ -29,6 +29,7 @@ BOARDS = [
     {"type": "crypto", "ext": ".bin", "fqbn": "arduino:samd:mkr1000"},
     {"type": "crypto", "ext": ".bin", "fqbn": "arduino:samd:mkrgsm1400"},
     {"type": "crypto", "ext": ".bin", "fqbn": "arduino:samd:mkrnb1500"},
+    {"type": "crypto", "ext": ".bin", "fqbn": "arduino:mbed_opta:opta"},
     {"type": "lora", "ext": ".bin", "fqbn": "arduino:samd:mkrwan1300"},
     {"type": "lora", "ext": ".bin", "fqbn": "arduino:samd:mkrwan1310"},
 ]

--- a/go.mod
+++ b/go.mod
@@ -9,7 +9,7 @@ require (
 	github.com/arduino/board-discovery v0.0.0-20211020061712-fd83c2e3c908 // indirect
 	github.com/arduino/go-paths-helper v1.7.0
 	github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b
-	github.com/arduino/iot-client-go v1.4.2
+	github.com/arduino/iot-client-go v1.4.4
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/google/go-cmp v0.5.6
 	github.com/h2non/filetype v1.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -78,8 +78,8 @@ github.com/arduino/go-properties-orderedmap v1.7.1/go.mod h1:DKjD2VXY/NZmlingh4l
 github.com/arduino/go-timeutils v0.0.0-20171220113728-d1dd9e313b1b/go.mod h1:uwGy5PpN4lqW97FiLnbcx+xx8jly5YuPMJWfVwwjJiQ=
 github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b h1:3PjgYG5gVPA7cipp7vIR2lF96KkEJIFBJ+ANnuv6J20=
 github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b/go.mod h1:iIPnclBMYm1g32Q5kXoqng4jLhMStReIP7ZxaoUC2y8=
-github.com/arduino/iot-client-go v1.4.2 h1:uZC8A26ytxSkuxNBFL2b/4w0TYjsR3ny2BbB5aVe4kw=
-github.com/arduino/iot-client-go v1.4.2/go.mod h1:gYvpMt7Qw+OSScTLyIlCnpbvy9y96ey/2zhB4w6FoK0=
+github.com/arduino/iot-client-go v1.4.4 h1:FICCXD5uCZ0scGG6RioOlpZamDqgSD1l/fQlFwKR284=
+github.com/arduino/iot-client-go v1.4.4/go.mod h1:gYvpMt7Qw+OSScTLyIlCnpbvy9y96ey/2zhB4w6FoK0=
 github.com/armon/circbuf v0.0.0-20150827004946-bbbad097214e/go.mod h1:3U/XgcO3hCbHZ8TKRvWD2dDTCfh9M9ya+I9JpbB7O8o=
 github.com/armon/go-metrics v0.0.0-20180917152333-f0300d1749da/go.mod h1:Q73ZrmVTwzkszR9V5SSuryQ31EELlFMUz1kKyl939pY=
 github.com/armon/go-metrics v0.3.10/go.mod h1:4O98XIr/9W0sxpJ8UaYkvjk10Iff7SnFrb4QAOwNTFc=

--- a/internal/iot/client.go
+++ b/internal/iot/client.go
@@ -48,7 +48,7 @@ func NewClient(cred *config.Credentials) (*Client, error) {
 
 // DeviceCreate allows to create a new device on Arduino IoT Cloud.
 // It returns the newly created device, and an error.
-func (cl *Client) DeviceCreate(ctx context.Context, fqbn, name, serial, dType string) (*iotclient.ArduinoDevicev2, error) {
+func (cl *Client) DeviceCreate(ctx context.Context, fqbn, name, serial, dType string, cType *string) (*iotclient.ArduinoDevicev2, error) {
 	ctx, err := ctxWithToken(ctx, cl.token)
 	if err != nil {
 		return nil, err
@@ -60,6 +60,11 @@ func (cl *Client) DeviceCreate(ctx context.Context, fqbn, name, serial, dType st
 		Serial: serial,
 		Type:   dType,
 	}
+
+	if cType != nil {
+		payload.ConnectionType = *cType
+	}
+
 	dev, _, err := cl.api.DevicesV2Api.DevicesV2Create(ctx, payload, nil)
 	if err != nil {
 		err = fmt.Errorf("creating device, %w", errorDetail(err))
@@ -85,7 +90,8 @@ func (cl *Client) DeviceLoraCreate(ctx context.Context, name, serial, devType, e
 		Type:          devType,
 		UserId:        "me",
 	}
-	dev, _, err := cl.api.LoraDevicesV1Api.LoraDevicesV1Create(ctx, payload)
+
+	dev, _, err := cl.api.LoraDevicesV1Api.LoraDevicesV1Create(ctx, payload, nil)
 	if err != nil {
 		err = fmt.Errorf("creating lora device: %w", errorDetail(err))
 		return nil, err


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
We want to support the Opta device in the cloud-acli

### Change description
<!-- What does your code do? -->
- Added device Opta fqbn in crypto fqbn list
- Added Opta fqbn and product ID in the OTA bin generation process
- Added Opta fqbn in provisioning bin generation
- Added Opta fqbn in the sync binaries workflow

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->
https://arduino.atlassian.net/browse/IOT-2273

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
