### PR TITLE
Update README with instructions about dependency from 'arduino-cli'

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This code is licensed under the terms of the GNU Affero General Public License v
 * Install [the latest release](https://github.com/arduino/arduino-cloud-cli/releases).
 * A client ID and a secret ID, retrievable from the [cloud](https://cloud.arduino.cc/home/api-keys) by creating a new API key.
 * Optional: the command `arduino-cloud-cli device create` requires the `arduino-cli` tool installed on the system. 
-  So, if you plan to create a device on the Arduino Cloud via CLI, you need to install the `arduino-cli` following the instructions at [https://arduino.github.io/arduino-cli/0.32/](https://arduino.github.io/arduino-cli/0.32/)
+  So, if you plan to create a device on the Arduino Cloud via CLI, you need to install the `arduino-cli` following the instructions at [https://arduino.github.io/arduino-cli/latest/](https://arduino.github.io/arduino-cli/latest/)
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This code is licensed under the terms of the GNU Affero General Public License v
 * Install [the latest release](https://github.com/arduino/arduino-cloud-cli/releases).
 * A client ID and a secret ID, retrievable from the [cloud](https://cloud.arduino.cc/home/api-keys) by creating a new API key.
 * Optional: the command `arduino-cloud-cli device create` requires the `arduino-cli` tool installed on the system. 
-  So, if you plan to create a device on the Arduino Cloud via CLI, you need to install the `arduino-cli` following the instructions at [https://arduino.github.io/arduino-cli/latest/](https://arduino.github.io/arduino-cli/latest/)
+  So, if you plan to create a device on the Arduino Cloud via CLI, you need to install the `arduino-cli` following the instructions at [https://arduino.github.io/arduino-cli/latest/installation](https://arduino.github.io/arduino-cli/latest/installation)
 
 
 ## Usage

--- a/README.md
+++ b/README.md
@@ -10,6 +10,9 @@ This code is licensed under the terms of the GNU Affero General Public License v
 
 * Install [the latest release](https://github.com/arduino/arduino-cloud-cli/releases).
 * A client ID and a secret ID, retrievable from the [cloud](https://cloud.arduino.cc/home/api-keys) by creating a new API key.
+* Optional: the command `arduino-cloud-cli device create` requires the `arduino-cli` tool installed on the system. 
+  So, if you plan to create a device on the Arduino Cloud via CLI, you need to install the `arduino-cli` following the instructions at [https://arduino.github.io/arduino-cli/0.32/](https://arduino.github.io/arduino-cli/0.32/)
+
 
 ## Usage
 


### PR DESCRIPTION
Update README with instructions about dependency from 'arduino-cli' to create a device

### Motivation
<!-- Why this pull request? -->
The creation of a device requires the `arduino-cli` installed, but this is not stated anywhere in the docs.
The documentation should be improved to reflect this dependency.

### Change description
<!-- What does your code do? -->
Updated README file with the proposed improvements.


### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->
Closes #136 

### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are properly filled.
* [x] Changes will be merged in `main`.
* [N/A] Changes are covered by tests.
* [N/A] Logging is meaningful in case of troubleshooting.
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
