### PR TITLE
Bump golang to version 1.17

### DIFF
--- a/.github/workflows/check-dependencies-task.yml
+++ b/.github/workflows/check-dependencies-task.yml
@@ -3,7 +3,7 @@ name: Check Dependencies
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
 
 # See: https://docs.github.com/en/actions/reference/events-that-trigger-workflows
 on:

--- a/.github/workflows/test-go-task.yml
+++ b/.github/workflows/test-go-task.yml
@@ -3,7 +3,7 @@ name: Test Go
 
 env:
   # See: https://github.com/actions/setup-go/tree/v2#readme
-  GO_VERSION: "1.16"
+  GO_VERSION: "1.17"
 
 # See: https://docs.github.com/en/free-pro-team@latest/actions/reference/events-that-trigger-workflows
 on:

--- a/DistTasks.yml
+++ b/DistTasks.yml
@@ -20,7 +20,7 @@ version: "3"
 
 vars:
   CONTAINER: "docker.elastic.co/beats-dev/golang-crossbuild"
-  GO_VERSION: "1.16.4"
+  GO_VERSION: "1.17.8"
   CHECKSUM_FILE: "{{.VERSION}}-checksums.txt"
 
 tasks:

--- a/go.mod
+++ b/go.mod
@@ -1,36 +1,91 @@
 module github.com/arduino/arduino-cloud-cli
 
-go 1.16
+go 1.17
 
 require (
-	github.com/Microsoft/go-winio v0.5.1 // indirect
 	github.com/antihax/optional v1.0.0
 	github.com/arduino/arduino-cli v0.0.0-20221116144942-76251df9241a
-	github.com/arduino/board-discovery v0.0.0-20211020061712-fd83c2e3c908 // indirect
 	github.com/arduino/go-paths-helper v1.7.0
 	github.com/arduino/go-win32-utils v0.0.0-20180330194947-ed041402e83b
 	github.com/arduino/iot-client-go v1.4.4
 	github.com/gofrs/uuid v4.2.0+incompatible
 	github.com/google/go-cmp v0.5.6
-	github.com/h2non/filetype v1.1.3 // indirect
 	github.com/howeyc/crc16 v0.0.0-20171223171357-2b2a61e366a6
-	github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff // indirect
-	github.com/kevinburke/ssh_config v1.1.0 // indirect
 	github.com/manifoldco/promptui v0.9.0
-	github.com/oleksandr/bonjour v0.0.0-20210301155756-30f43c61b915 // indirect
-	github.com/sergi/go-diff v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.3.0
 	github.com/spf13/viper v1.10.1
 	github.com/stretchr/testify v1.8.0
-	github.com/xanzy/ssh-agent v0.3.1 // indirect
 	go.bug.st/cleanup v1.0.0
 	go.bug.st/serial v1.3.3
-	go.bug.st/serial.v1 v0.0.0-20191202182710-24a6610f0541 // indirect
 	golang.org/x/crypto v0.0.0-20211215153901-e495a2d5b3d3
 	golang.org/x/oauth2 v0.0.0-20211104180415-d3ed0bb246c8
-	golang.org/x/text v0.4.0 // indirect
 	google.golang.org/grpc v1.43.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools v2.2.0+incompatible
+)
+
+require (
+	github.com/Microsoft/go-winio v0.5.1 // indirect
+	github.com/arduino/board-discovery v0.0.0-20211020061712-fd83c2e3c908 // indirect
+	github.com/arduino/go-properties-orderedmap v1.7.1 // indirect
+	github.com/chzyer/readline v0.0.0-20180603132655-2972be24d48e // indirect
+	github.com/cmaglie/pb v1.0.27 // indirect
+	github.com/codeclysm/cc v1.2.2 // indirect
+	github.com/codeclysm/extract/v3 v3.0.2 // indirect
+	github.com/creack/goselect v0.1.2 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/emirpasic/gods v1.12.0 // indirect
+	github.com/fatih/color v1.13.0 // indirect
+	github.com/fluxio/iohelpers v0.0.0-20160419043813-3a4dd67a94d2 // indirect
+	github.com/fluxio/multierror v0.0.0-20160419044231-9c68d39025e5 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
+	github.com/golang/protobuf v1.5.2 // indirect
+	github.com/h2non/filetype v1.1.3 // indirect
+	github.com/hashicorp/hcl v1.0.0 // indirect
+	github.com/inconshreveable/mousetrap v1.0.0 // indirect
+	github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 // indirect
+	github.com/josharian/intern v1.0.0 // indirect
+	github.com/juju/errors v0.0.0-20210818161939-5560c4c073ff // indirect
+	github.com/kevinburke/ssh_config v1.1.0 // indirect
+	github.com/leonelquinteros/gotext v1.4.0 // indirect
+	github.com/magiconair/properties v1.8.5 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
+	github.com/mattn/go-colorable v0.1.12 // indirect
+	github.com/mattn/go-isatty v0.0.14 // indirect
+	github.com/mattn/go-runewidth v0.0.13 // indirect
+	github.com/miekg/dns v1.1.43 // indirect
+	github.com/mitchellh/go-homedir v1.1.0 // indirect
+	github.com/mitchellh/mapstructure v1.4.3 // indirect
+	github.com/oleksandr/bonjour v0.0.0-20210301155756-30f43c61b915 // indirect
+	github.com/pelletier/go-toml v1.9.4 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/pmylund/sortutil v0.0.0-20120526081524-abeda66eb583 // indirect
+	github.com/rivo/uniseg v0.2.0 // indirect
+	github.com/sergi/go-diff v1.2.0 // indirect
+	github.com/smartystreets/goconvey v1.6.4 // indirect
+	github.com/spf13/afero v1.6.0 // indirect
+	github.com/spf13/cast v1.4.1 // indirect
+	github.com/spf13/jwalterweatherman v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
+	github.com/src-d/gcfg v1.4.0 // indirect
+	github.com/stretchr/objx v0.4.0 // indirect
+	github.com/subosito/gotenv v1.2.0 // indirect
+	github.com/xanzy/ssh-agent v0.3.1 // indirect
+	go.bug.st/downloader/v2 v2.1.1 // indirect
+	go.bug.st/relaxed-semver v0.9.0 // indirect
+	go.bug.st/serial.v1 v0.0.0-20191202182710-24a6610f0541 // indirect
+	golang.org/x/net v0.0.0-20220722155237-a158d28d115b // indirect
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 // indirect
+	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
+	golang.org/x/text v0.4.0 // indirect
+	google.golang.org/appengine v1.6.7 // indirect
+	google.golang.org/genproto v0.0.0-20211208223120-3a66f561d7aa // indirect
+	google.golang.org/protobuf v1.27.1 // indirect
+	gopkg.in/ini.v1 v1.66.2 // indirect
+	gopkg.in/src-d/go-billy.v4 v4.3.2 // indirect
+	gopkg.in/src-d/go-git.v4 v4.13.1 // indirect
+	gopkg.in/warnings.v0 v0.1.2 // indirect
+	gopkg.in/yaml.v2 v2.4.0 // indirect
 )


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
Bumping golang version to `1.17` allows to update some of this project's dependencies.
### Change description
<!-- What does your code do? -->
Golang version is updated to `1.17` in `go.mod` and in this project's workflows and `DistTasks.yml.`
### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->
Related to https://github.com/arduino/arduino-cloud-cli/issues/110
### Reviewer checklist

* [x] PR address a single concern.
* [x] PR title and description are properly filled.
* [x] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [x] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
