### PR TITLE
[IOT-2732] Export timezone for things

### DIFF
--- a/internal/template/extract.go
+++ b/internal/template/extract.go
@@ -32,6 +32,7 @@ import (
 func FromThing(thing *iotclient.ArduinoThing) map[string]interface{} {
 	template := make(map[string]interface{})
 	template["name"] = thing.Name
+	template["timezone"] = thing.Timezone
 
 	// Extract template from thing structure
 	var props []map[string]interface{}


### PR DESCRIPTION
### Motivation
<!-- Why this pull request? -->
Currently, when the configuration of a thing is exported, the timezone is ignored. So if a user use the extracted template to create a new thing, a default timezone is assigned

### Change description
<!-- What does your code do? -->
- Timezone is exported in the thing export command

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->
https://arduino.atlassian.net/browse/IOT-2732

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
