### PR TITLE
Update API credentials URL in `credentials init` message

### DIFF
--- a/cli/credentials/init.go
+++ b/cli/credentials/init.go
@@ -99,7 +99,7 @@ func runInitCommand(flags *initFlags) error {
 	}
 
 	// Take needed credentials starting an interactive mode
-	feedback.Print("To obtain your API credentials visit https://create.arduino.cc/iot/integrations")
+	feedback.Print("To obtain your API credentials visit https://app.arduino.cc/api-keys")
 	id, key, org, err := paramsPrompt()
 	if err != nil {
 		return fmt.Errorf("cannot take credentials params: %w", err)


### PR DESCRIPTION
### Motivation
The `arduino-cloud-cli credentials init` command prints a helpful message providing the user with guidance about how to obtain the Arduino Cloud API credentials.

It seems the URL of the Arduino Cloud API Keys page changed due to restructuring of the site since the time this message was written. A redirect was not set up from the old URL to the new URL so the previous URL in the message now only redirects to the Arduino Cloud home page:

> To obtain your API credentials visit https://create.arduino.cc/iot/integrations

### Change description

The URL is hereby updated to the modern URL of the API Keys page: https://app.arduino.cc/api-keys

### Additional Notes

Although the incorrect/missing redirect should also be fixed, it is still best to avoid a reliance on such redirects since they tend to be ephemeral.

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
