### PR TITLE
[WIRE-244] Fix: export options of a scheduler widget in the dashboard extract command

### DIFF
--- a/internal/template/filter.go
+++ b/internal/template/filter.go
@@ -29,6 +29,9 @@ var (
 		"showLabels":    {},
 		"step":          {},
 		"vertical":      {},
+		"dateFormat":    {},
+		"timeFormat":    {},
+		"display":       {},
 	}
 )
 


### PR DESCRIPTION
When a dashboard containing a scheduler widget is exported, and then a new dashboard is created from the exported template, the options of a scheduler widget are lost in the process. As a consequence, the GUI (both Web and Mobile) can't render the scheduler widget.

### Motivation
<!-- Why this pull request? -->

### Change description
<!-- What does your code do? -->

### Additional Notes
<!-- Link any useful metadata: Jira task, GitHub issue, ... -->

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
