### PR TITLE
Pass organization header while creating token

### DIFF
--- a/cli/device/list.go
+++ b/cli/device/list.go
@@ -92,6 +92,11 @@ func (r listResult) Data() interface{} {
 	return r.devices
 }
 
+func cleanStrings(serial string) string {
+	serial = strings.Trim(serial, "\n")
+	return strings.Trim(serial, " ")
+}
+
 func (r listResult) String() string {
 	if len(r.devices) == 0 {
 		return "No devices found."
@@ -100,11 +105,11 @@ func (r listResult) String() string {
 	t.SetHeader("Name", "ID", "Board", "FQBN", "SerialNumber", "Status", "Tags")
 	for _, device := range r.devices {
 		t.AddRow(
-			device.Name,
+			cleanStrings(device.Name),
 			device.ID,
 			device.Board,
 			device.FQBN,
-			device.Serial,
+			cleanStrings(device.Serial),
 			dereferenceString(device.Status),
 			strings.Join(device.Tags, ","),
 		)

--- a/internal/iot/client.go
+++ b/internal/iot/client.go
@@ -560,15 +560,15 @@ func (cl *Client) TemplateApply(ctx context.Context, id, thingId, prefix, device
 	return dev, nil
 }
 
-func (cl *Client) setup(client, secret, organization string) error {
+func (cl *Client) setup(client, secret, organizationId string) error {
 	baseURL := GetArduinoAPIBaseURL()
 
 	// Configure a token source given the user's credentials.
-	cl.token = NewUserTokenSource(client, secret, baseURL)
+	cl.token = NewUserTokenSource(client, secret, baseURL, organizationId)
 
 	config := iotclient.NewConfiguration()
-	if organization != "" {
-		config.AddDefaultHeader("X-Organization", organization)
+	if organizationId != "" {
+		config.AddDefaultHeader("X-Organization", organizationId)
 	}
 	config.Servers = iotclient.ServerConfigurations{
 		{

--- a/internal/iot/token.go
+++ b/internal/iot/token.go
@@ -39,10 +39,13 @@ func GetArduinoAPIBaseURL() string {
 }
 
 // Build a new token source to forge api JWT tokens based on provided credentials
-func NewUserTokenSource(client, secret, baseURL string) oauth2.TokenSource {
+func NewUserTokenSource(client, secret, baseURL, organizationId string) oauth2.TokenSource {
 	// We need to pass the additional "audience" var to request an access token.
 	additionalValues := url.Values{}
 	additionalValues.Add("audience", "https://api2.arduino.cc/iot")
+	if organizationId != "" {
+		additionalValues.Add("organization_id", organizationId)
+	}
 	// Set up OAuth2 configuration.
 	config := cc.Config{
 		ClientID:       client,

--- a/internal/ota-api/client.go
+++ b/internal/ota-api/client.go
@@ -49,7 +49,7 @@ type OtaApiClient struct {
 
 func NewClient(credentials *config.Credentials) *OtaApiClient {
 	host := iot.GetArduinoAPIBaseURL()
-	tokenSource := iot.NewUserTokenSource(credentials.Client, credentials.Secret, host)
+	tokenSource := iot.NewUserTokenSource(credentials.Client, credentials.Secret, host, credentials.Organization)
 	return &OtaApiClient{
 		client:       &http.Client{},
 		src:          tokenSource,

--- a/internal/storage-api/client.go
+++ b/internal/storage-api/client.go
@@ -57,7 +57,7 @@ func getArduinoAPIBaseURL() string {
 func NewClient(credentials *config.Credentials) *StorageApiClient {
 	host := getArduinoAPIBaseURL()
 	iothost := iot.GetArduinoAPIBaseURL()
-	tokenSource := iot.NewUserTokenSource(credentials.Client, credentials.Secret, iothost)
+	tokenSource := iot.NewUserTokenSource(credentials.Client, credentials.Secret, iothost, credentials.Organization)
 	return &StorageApiClient{
 		client:       &http.Client{},
 		src:          tokenSource,


### PR DESCRIPTION
### Motivation
Organization header was not set in token creation due to oauth2 limitations. /token generation endpoint has been enhanced to receive organization_id other than via Header

### Reviewer checklist

* [ ] PR address a single concern.
* [ ] PR title and description are properly filled.
* [ ] Changes will be merged in `main`.
* [ ] Changes are covered by tests.
* [ ] Logging is meaningful in case of troubleshooting.
* [ ] History is clean, commit messages are meaningful (see `CONTRIBUTING.md`) and are well formatted.
